### PR TITLE
Add Unlogged option

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,79 @@
+package postgresStore
+
+type ConnectionConfig struct {
+	Host        string
+	Port        int
+	Username    string
+	Password    string
+	DBName      string
+	SslMode     string
+	StorageMode string
+	Unlogged    bool
+	ConnStr     string
+}
+
+// StorageMode
+// see createSchema function
+const (
+	StorageModeExtended = "EXTENDED"
+	StorageModeExternal = "EXTERNAL"
+)
+
+var DefaultConnectionConfig = ConnectionConfig{
+	Host:        "localhost",
+	Port:        5432,
+	Username:    "postgres",
+	Password:    "password",
+	DBName:      "postgres",
+	SslMode:     "disable",
+	StorageMode: StorageModeExtended,
+	Unlogged:    false,
+}
+
+// SetHost sets the host parameter in the connectionConfig
+func (c ConnectionConfig) SetHost(host string) ConnectionConfig {
+	c.Host = host
+	return c
+}
+
+// SetPort sets the port parameter in the connectionConfig
+func (c ConnectionConfig) SetPort(port int) ConnectionConfig {
+	c.Port = port
+	return c
+}
+
+// SetUsername sets the username parameter in the connectionConfig
+func (c ConnectionConfig) SetUsername(username string) ConnectionConfig {
+	c.Username = username
+	return c
+}
+
+// SetPassword sets the password parameter in the connectionConfig
+func (c ConnectionConfig) SetPassword(password string) ConnectionConfig {
+	c.Password = password
+	return c
+}
+
+// SetDBName sets the DBName parameter in the connectionConfig
+func (c ConnectionConfig) SetDBName(dbname string) ConnectionConfig {
+	c.DBName = dbname
+	return c
+}
+
+// SetSsLMode sets the SsLMode parameter in the connectionConfig
+func (c ConnectionConfig) SetSslMode(sslMode string) ConnectionConfig {
+	c.SslMode = sslMode
+	return c
+}
+
+// SetStorageMode sets the StorageMode parameter in the connectionConfig
+func (c ConnectionConfig) SetStorageMode(storageMode string) ConnectionConfig {
+	c.StorageMode = storageMode
+	return c
+}
+
+// SetUnlogged sets the unlogged parameter in the connectionConfig
+func (c ConnectionConfig) SetUnlogged(unlogged bool) ConnectionConfig {
+	c.Unlogged = unlogged
+	return c
+}

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,6 +2,8 @@ module postgresStore/example
 
 go 1.20
 
+replace github.com/mathisve/postgresStore v0.2.5 => /Users/mathis/Developer/postgresStore
+
 require github.com/mathisve/postgresStore v0.2.5
 
 require github.com/lib/pq v1.10.7 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,4 +1,2 @@
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/mathisve/postgresStore v0.2.5 h1:c0drvPr8dvVzRfXiIHeu0quA/5V6x8kCxlNth8W4jVY=
-github.com/mathisve/postgresStore v0.2.5/go.mod h1:/EE2xNSHBk3MWP7xB7/FhjhsvrDTmiy8c5gXMIGo794=

--- a/example/main.go
+++ b/example/main.go
@@ -14,29 +14,25 @@ const (
 func main() {
 
 	// create connection
-	c, err := postgresStore.NewConnection(postgresStore.DefaultConnectionConfig)
+	c, err := postgresStore.NewConnection(postgresStore.DefaultConnectionConfig.SetUnlogged(true))
 	if err != nil {
 		log.Println(err)
 	}
 
 	// open file
-	file, err := os.Open(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		log.Println(err)
 	}
 
-	// read file
-	var data []byte
-	_, err = file.Read(data)
-	if err != nil {
-		log.Println(err)
-	}
+	log.Println(data)
 
 	// upload objects
 	err = c.UploadObject(postgresStore.Object{
 		ObjectName: filename,
 		Bytes:      data,
 	})
+
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
Turns out, creating an unlogged table was the default. 
This isn't really desirable behavior as an unlogged table is not durable. But we'd love to give you the option to use it at your discretion. 

Hence this PR.